### PR TITLE
[Bug] Remove Poetry Path Additional Assignment + Fix Indentation on Readme

### DIFF
--- a/examples/gen-ai-hello-world/README.md
+++ b/examples/gen-ai-hello-world/README.md
@@ -11,8 +11,8 @@ This is an example of how to use the gllm-pipeline library to build a simple RAG
 > You need to fulfill the prerequisites to run the script. They will be checked automatically when you execute it.
 
 1. **Python v3.11 or v3.12**.
-> [!CAUTION]
-> For Windows, we do not recommend to use Python installed via Microsoft Store. If you have any Python installed from Microsoft Store, please uninstall them and use either Python installer or Conda.
+    > [!CAUTION]
+    > For Windows, we do not recommend to use Python installed via Microsoft Store. If you have any Python installed from Microsoft Store, please uninstall them and use either Python installer or Conda.
 
    - Using Python installer: 
    
@@ -24,11 +24,11 @@ This is an example of how to use the gllm-pipeline library to build a simple RAG
    
       You can use [Miniconda](http://conda.pydata.org/miniconda.html) to install and manage Python versions.
 
-3. **Google Cloud CLI v493.0.0 or above**.
+2. **Google Cloud CLI v493.0.0 or above**.
 
    - You can install it by following [this instruction](https://cloud.google.com/sdk/docs/install).
 
-4. **Access to the GDP Labs Google Artifact Registry**.
+3. **Access to the GDP Labs Google Artifact Registry**.
    - If you don’t have access, please make a request to ticket(at)gdplabs.id.
 
 ## Running the code
@@ -52,6 +52,7 @@ This is an example of how to use the gllm-pipeline library to build a simple RAG
       ```bash
       ./local-start.sh
       ```
+      > [!NOTE]
       > On Windows, you can either install [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) or execute the batch file in Windows Powershell or Command Prompt as described in the next section.
 
    - For Windows Command Prompt:

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -69,20 +69,6 @@ get_python_path() {
     log "PYTHON_PATH will be set to: $PYTHON_PATH"
 }
 
-get_shell_rc() {
-    case "$SHELL" in
-        */bash)
-            echo "$HOME/.bashrc"
-            ;;
-        */zsh)
-            echo "$HOME/.zshrc"
-            ;;
-        *)
-            handle_error "Unsupported shell. Please update your PATH manually and rerun the local-start.sh script again."
-            ;;
-    esac
-}
-
 install_command() {
     local cmd=$1
     local required_version=$2

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -84,17 +84,6 @@ get_shell_rc() {
     esac
 }
 
-update_shell_config() {
-    local shell_rc=$(get_shell_rc)
-
-    # Source the shell configuration file to update the current session
-    if [ -f "$shell_rc" ]; then
-        # shellcheck disable=SC1090
-        source "$shell_rc" || log "Failed to source $shell_rc in ${SHELL##*/}."
-        log "Sourced $shell_rc to update PATH for the current session."
-    fi
-}
-
 install_command() {
     local cmd=$1
     local required_version=$2
@@ -107,10 +96,6 @@ install_command() {
         if ! curl -sSL https://install.python-poetry.org | $PYTHON_CMD -; then
             handle_error "Failed to install $cmd version $required_version."
         fi
-
-        # Update PATH in both .bashrc and .zshrc for future interactive sessions
-        
-        update_shell_config
 
         # Wait for a moment to ensure the system recognizes the new installation
         sleep 2

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -70,7 +70,7 @@ get_python_path() {
     log "PYTHON_PATH will be set to: $PYTHON_PATH"
 }
 
-update_poetry_path() {
+get_poetry_path() {
     # Determine the poetry path based on the operating system
     if [[ "$OSTYPE" == "darwin"* ]]; then
         POETRY_PATH="$HOME/Library/Application Support/pypoetry/venv/bin/poetry" # macOS
@@ -88,7 +88,7 @@ update_poetry_path() {
         handle_error "Unsupported operating system or POETRY_HOME not set."
     fi
 
-    log "POETRY_PATH: $POETRY_PATH"
+    log "Detected Poetry path: $POETRY_PATH"
 }
 
 install_command() {
@@ -104,7 +104,7 @@ install_command() {
             handle_error "Failed to install $cmd version $required_version."
         fi
 
-        update_poetry_path
+        get_poetry_path
     else
         if [[ "$cmd" == "$PYTHON_CMD" ]]; then
             handle_error "Please use Python version ${PYTHON_VERSIONS[*]}."

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -9,6 +9,7 @@ LOG_FILE="./deploy.log"
 
 PYTHON_PATH=""
 POETRY_PATH=""
+
 # colors for logging
 COLOR_ERROR="\033[31m"
 COLOR_WARNING="\033[33m"
@@ -270,7 +271,7 @@ setup_poetry_http_basic() {
 install_dependencies() {
     log "Installing dependencies..."
 
-    if ! poetry install; then
+    if ! "$POETRY_PATH" install; then
         handle_error "Failed to install dependencies. Please try again."
     fi
 }
@@ -294,7 +295,7 @@ main() {
     log "${COLOR_SUCCESS}gen-ai-hello-world example ready to run.$COLOR_RESET"
     
     log "${COLOR_INFO}Running gen-ai-hello-world example...$COLOR_RESET"
-    poetry run $PYTHON_CMD gen_ai_hello_world/main.py
+    "$POETRY_PATH" run $PYTHON_CMD gen_ai_hello_world/main.py
     log "${COLOR_SUCCESS}gen-ai-hello-world example finished running.$COLOR_RESET"
 }
 

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -96,9 +96,6 @@ install_command() {
         if ! curl -sSL https://install.python-poetry.org | $PYTHON_CMD -; then
             handle_error "Failed to install $cmd version $required_version."
         fi
-
-        # Wait for a moment to ensure the system recognizes the new installation
-        sleep 2
     else
         if [[ "$cmd" == "$PYTHON_CMD" ]]; then
             handle_error "Please use Python version ${PYTHON_VERSIONS[*]}."

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -95,46 +95,6 @@ update_shell_config() {
     fi
 }
 
-update_poetry_path() {
-    local shell_rc=$(get_shell_rc)
-    local poetry_export_path
-
-    # Determine the poetry path based on the operating system
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        POETRY_PATH="$HOME/Library/Application Support/pypoetry/venv/bin/poetry" # macOS
-        poetry_export_path="$HOME/Library/Application Support/pypoetry/venv/bin"
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        if grep -q "microsoft" /proc/version 2>/dev/null; then
-            POETRY_PATH="$HOME/.local/bin/poetry" # WSL
-            poetry_export_path="$HOME/.local/bin"
-        else
-            POETRY_PATH="$HOME/.local/share/pypoetry/venv/bin/poetry" # Linux/Unix
-            poetry_export_path="$HOME/.local/share/pypoetry/venv/bin"
-        fi
-    elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
-        POETRY_PATH="%APPDATA%\\pypoetry\\venv\\Scripts\\poetry" # Windows
-        poetry_export_path="%APPDATA%\\pypoetry\\venv\\Scripts"
-    elif [[ -n "$POETRY_HOME" ]]; then
-        POETRY_PATH="$POETRY_HOME/venv/bin/poetry" # If $POETRY_HOME is set
-        poetry_export_path="$POETRY_HOME/venv/bin"
-    else
-        handle_error "Unsupported operating system or POETRY_HOME not set."
-    fi
-
-    log "POETRY_PATH will be set to: $POETRY_PATH"
-
-    if [[ -f "$shell_rc" && -w "$shell_rc" ]]; then
-        if ! grep -q "$poetry_export_path" "$shell_rc" 2>/dev/null; then
-            echo "export PATH=\"$poetry_export_path:\$PATH\"" >> "$shell_rc"
-            log "Added Poetry to PATH in $shell_rc"
-        else
-            log "Poetry path already exists in $shell_rc"
-        fi
-    else
-        log "Shell configuration file $shell_rc does not exist or is not writable."
-    fi
-}
-
 install_command() {
     local cmd=$1
     local required_version=$2
@@ -149,7 +109,7 @@ install_command() {
         fi
 
         # Update PATH in both .bashrc and .zshrc for future interactive sessions
-        update_poetry_path
+        
         update_shell_config
 
         # Wait for a moment to ensure the system recognizes the new installation

--- a/examples/gen-ai-hello-world/local-start.sh
+++ b/examples/gen-ai-hello-world/local-start.sh
@@ -8,7 +8,6 @@ PYTHON_CMD="python"
 LOG_FILE="./deploy.log"
 
 PYTHON_PATH=""
-POETRY_PATH=""
 
 # colors for logging
 COLOR_ERROR="\033[31m"
@@ -262,7 +261,7 @@ setup_poetry_http_basic() {
 install_dependencies() {
     log "Installing dependencies..."
 
-    if ! "$POETRY_PATH" install; then
+    if ! poetry install; then
         handle_error "Failed to install dependencies. Please try again."
     fi
 }
@@ -286,7 +285,7 @@ main() {
     log "${COLOR_SUCCESS}gen-ai-hello-world example ready to run.$COLOR_RESET"
     
     log "${COLOR_INFO}Running gen-ai-hello-world example...$COLOR_RESET"
-    "$POETRY_PATH" run $PYTHON_CMD gen_ai_hello_world/main.py
+    poetry run $PYTHON_CMD gen_ai_hello_world/main.py
     log "${COLOR_SUCCESS}gen-ai-hello-world example finished running.$COLOR_RESET"
 }
 


### PR DESCRIPTION
slack convo: https://glair-2018.slack.com/archives/C06D7HWF882/p1736912853820799?thread_ts=1736220260.609259&cid=C06D7HWF882

Initial Readme:
![image](https://github.com/user-attachments/assets/46feeeaa-4479-410d-9109-e54cc9258476)

- Notice that there is no 2 between 1 and 3
- The indentation of the bullet children are different

----

Tested twice using these steps
1. uninstall poetry
2. made sure that the poetry is removed from PATH (from zshrc)
3. remove .venv
4. run `./local-start.sh`

once with these steps
1. recloned the repo and go to this branch
2. uninstall poetry
3. made sure that the poetry is removed from PATH (from zshrc)
4. run `./local-start.sh` , filled in the env values, re-run the `local-start.sh`

And once with these steps
1. activate conda env
2. uninstall poetry
3. made sure that the poetry is removed from PATH (from zshrc)
4. remove .venv
5. run `./local-start.sh` 