### PR TITLE
feat(nlweb): add rss2blogschema

### DIFF
--- a/examples/nl-web/code/requirements.txt
+++ b/examples/nl-web/code/requirements.txt
@@ -21,4 +21,3 @@ pyyaml>=6.0.1
 feedparser>=6.0.1
 httpx>=0.28.1
 seaborn>=0.13.0
-feedparser==6.0.11

--- a/examples/nl-web/code/requirements.txt
+++ b/examples/nl-web/code/requirements.txt
@@ -21,3 +21,4 @@ pyyaml>=6.0.1
 feedparser>=6.0.1
 httpx>=0.28.1
 seaborn>=0.13.0
+feedparser==6.0.11

--- a/examples/nl-web/code/tools/rss2blogschema.py
+++ b/examples/nl-web/code/tools/rss2blogschema.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+rss2blogschema.py  –  Convert an RSS feed to one-line-per-post JSON-LD (BlogPosting)
+
+usage:
+    python rss2blogschema.py https://example.com/blog/rss.xml > blog.jsonl
+    python rss2blogschema.py path/to/local.xml > blog.jsonl
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import feedparser
+
+ISO_FMT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def iso8601(struct_time):
+    """Convert feedparser’s time struct → ISO-8601 string (UTC)."""
+    if not struct_time:
+        return None
+    dt = datetime(*struct_time[:6], tzinfo=timezone.utc)
+    return dt.strftime(ISO_FMT)
+
+
+def parse_feed(source):
+    """
+    Parse a feed from URL, file path or stdin.
+    Returns (channel_meta, [entry_dicts…]).
+    """
+    if source == "-":                               # read from stdin
+        raw = sys.stdin.read()
+        feed = feedparser.parse(raw)
+    elif Path(source).exists():                     # local file
+        feed = feedparser.parse(Path(source).read_bytes())
+    else:                                           # assume URL
+        feed = feedparser.parse(source)
+
+    channel = feed.feed
+    channel_meta = {
+        "@type": "Blog",
+        "name":  channel.get("title", ""),
+        "description": channel.get("subtitle", "") or channel.get("description", ""),
+        "url":   channel.get("link", "")
+    }
+    return channel_meta, feed.entries
+
+
+def entry_to_jsonld(entry, channel_meta):
+    """Build a JSON-LD BlogPosting object from one feed entry."""
+    # Pick first media:content or media:thumbnail if present
+    img = None
+    if entry.get("media_content"):
+        img = entry.media_content[0].get("url")
+    elif entry.get("media_thumbnail"):
+        img = entry.media_thumbnail[0].get("url")
+
+    jsonld = {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        # headline maps best to <title>
+        "headline": entry.get("title", "").strip(),
+        "description": (entry.get("summary", "") or entry.get("description", "")).strip(),
+        "datePublished": iso8601(entry.get("published_parsed")),
+        "url": entry.get("link", "").strip(),
+        # image may be None if feed provides none
+        **({"image": img} if img else {}),
+        # Relate post to its parent blog
+        "isPartOf": channel_meta,
+    }
+    return jsonld
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Convert RSS → newline-delimited JSON-LD BlogPosting objects")
+    ap.add_argument("source", help="Feed URL, local file path, or '-' to read from stdin")
+    args = ap.parse_args()
+
+    channel_meta, entries = parse_feed(args.source)
+
+    for e in entries:
+        print(json.dumps(entry_to_jsonld(e, channel_meta), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/nl-web/code/tools/url_replacer.py
+++ b/examples/nl-web/code/tools/url_replacer.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+
+"""
+URL Replacer Script
+A utility script for replacing URLs and other text patterns in files
+Usage: python url_replacer.py [options]
+"""
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+class Colors:
+    """ANSI color codes for terminal output"""
+    RED = '\033[0;31m'
+    GREEN = '\033[0;32m'
+    YELLOW = '\033[1;33m'
+    BLUE = '\033[0;34m'
+    NC = '\033[0m'  # No Color
+
+
+def print_info(message):
+    """Print info message with blue color"""
+    print(f"{Colors.BLUE}[INFO]{Colors.NC} {message}")
+
+
+def print_success(message):
+    """Print success message with green color"""
+    print(f"{Colors.GREEN}[SUCCESS]{Colors.NC} {message}")
+
+
+def print_warning(message):
+    """Print warning message with yellow color"""
+    print(f"{Colors.YELLOW}[WARNING]{Colors.NC} {message}")
+
+
+def print_error(message):
+    """Print error message with red color"""
+    print(f"{Colors.RED}[ERROR]{Colors.NC} {message}")
+
+
+def create_backup(file_path):
+    """Create backup of file with timestamp"""
+    if not os.path.isfile(file_path):
+        print_error(f"File not found: {file_path}")
+        sys.exit(1)
+    
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_file = f"{file_path}.backup.{timestamp}"
+    
+    try:
+        shutil.copy2(file_path, backup_file)
+        print_info(f"Backup created: {backup_file}")
+    except Exception as e:
+        print_error(f"Failed to create backup: {e}")
+        sys.exit(1)
+
+
+def replace_url(old_url, new_url, file_path, create_backup_flag=False):
+    """Replace URLs in file"""
+    if not os.path.isfile(file_path):
+        print_error(f"File not found: {file_path}")
+        sys.exit(1)
+    
+    # Create backup if requested
+    if create_backup_flag:
+        create_backup(file_path)
+    
+    try:
+        # Read file content
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Count occurrences before replacement
+        count_before = content.count(old_url)
+        
+        if count_before == 0:
+            print_warning(f"No occurrences of '{old_url}' found in {file_path}")
+            return
+        
+        print_info(f"Found {count_before} occurrences of '{old_url}'")
+        
+        # Perform replacement
+        new_content = content.replace(old_url, new_url)
+        
+        # Write back to file
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        
+        # Count occurrences after replacement
+        count_after = new_content.count(new_url)
+        
+        print_success("Replacement completed!")
+        print_info(f"Replaced {count_before} occurrences")
+        print_info(f"Found {count_after} occurrences of new URL")
+        
+    except Exception as e:
+        print_error(f"Error processing file: {e}")
+        sys.exit(1)
+
+
+def count_pattern(pattern, file_path):
+    """Count occurrences of a pattern in file"""
+    if not os.path.isfile(file_path):
+        print_error(f"File not found: {file_path}")
+        sys.exit(1)
+    
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Use regex for more flexible pattern matching
+        matches = re.findall(re.escape(pattern), content)
+        count = len(matches)
+        
+        print_info(f"Pattern '{pattern}' found {count} times in {file_path}")
+        
+    except Exception as e:
+        print_error(f"Error reading file: {e}")
+        sys.exit(1)
+
+
+def verify_replacement(old_url, new_url, file_path):
+    """Verify replacement results"""
+    if not os.path.isfile(file_path):
+        print_error(f"File not found: {file_path}")
+        sys.exit(1)
+    
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        old_count = content.count(old_url)
+        new_count = content.count(new_url)
+        
+        print_info("Verification Results:")
+        print_info(f"Old URL '{old_url}': {old_count} occurrences")
+        print_info(f"New URL '{new_url}': {new_count} occurrences")
+        
+        if old_count == 0 and new_count > 0:
+            print_success("Replacement appears successful!")
+        elif old_count > 0:
+            print_warning("Some old URLs may still exist")
+        else:
+            print_warning("No URLs found")
+            
+    except Exception as e:
+        print_error(f"Error reading file: {e}")
+        sys.exit(1)
+
+
+def main():
+    """Main function with argument parsing"""
+    parser = argparse.ArgumentParser(
+        description="URL Replacer Script - A utility for text replacement operations",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python url_replacer.py -r old_url new_url file.json
+  python url_replacer.py -c 'pattern' file.txt
+  python url_replacer.py -b -r old_url new_url file.json
+  python url_replacer.py -v old_url new_url file.json
+        """
+    )
+    
+    # Operation arguments (mutually exclusive)
+    operation_group = parser.add_mutually_exclusive_group(required=True)
+    operation_group.add_argument('-r', '--replace-url', action='store_true',
+                                help='Replace URLs in a file')
+    operation_group.add_argument('-c', '--count', action='store_true',
+                                help='Count occurrences of a pattern')
+    operation_group.add_argument('-v', '--verify', action='store_true',
+                                help='Verify replacement results')
+    
+    # Optional arguments
+    parser.add_argument('-b', '--backup', action='store_true',
+                       help='Create backup before replacement')
+    
+    # Positional arguments
+    parser.add_argument('args', nargs='*', help='Arguments for the operation')
+    
+    args = parser.parse_args()
+    
+    # Execute based on operation
+    if args.replace_url:
+        if len(args.args) < 3:
+            print_error("Replace operation requires: old_url new_url file")
+            parser.print_help()
+            sys.exit(1)
+        replace_url(args.args[0], args.args[1], args.args[2], args.backup)
+        
+    elif args.count:
+        if len(args.args) < 2:
+            print_error("Count operation requires: pattern file")
+            parser.print_help()
+            sys.exit(1)
+        count_pattern(args.args[0], args.args[1])
+        
+    elif args.verify:
+        if len(args.args) < 3:
+            print_error("Verify operation requires: old_url new_url file")
+            parser.print_help()
+            sys.exit(1)
+        verify_replacement(args.args[0], args.args[1], args.args[2])
+
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
Add `rss2blogschema.py` and `url_replacer.py` to support CATAPA blog RSS data loading.

Part of https://github.com/GDP-ADMIN/catapa-platdev/issues/7592