### PR TITLE
[Arxiv MCP] Feature and Fix: Fix capability of fetching old paper

### DIFF
--- a/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_configs/configs.py
+++ b/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_configs/configs.py
@@ -15,7 +15,7 @@ mcp_config_stdio = {
 
 mcp_config_arxiv_sse = {
     "arxiv_tools": {
-        "url": "http://localhost:8006/arxiv/sse",
+        "url": "http://localhost:8006/sse",
         "transport": "sse",
     }
 }

--- a/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_configs/configs.py
+++ b/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_configs/configs.py
@@ -15,7 +15,7 @@ mcp_config_stdio = {
 
 mcp_config_arxiv_sse = {
     "arxiv_tools": {
-        "url": "http://localhost:8006/sse",
+        "url": "http://localhost:8006/arxiv/sse",
         "transport": "sse",
     }
 }

--- a/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_servers/arxiv/Dockerfile
+++ b/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_servers/arxiv/Dockerfile
@@ -19,8 +19,17 @@ RUN git clone https://github.com/samuellusandi/multi-mcp.git .
 # Install multi-mcp dependencies
 RUN uv sync
 
-# Install arxiv-mcp-server globally
-RUN uv tool install arxiv-mcp-server
+# Clone arxiv-mcp-server fixed
+RUN git clone https://github.com/RavindraGDP/arxiv-mcp-server.git
+
+# Change directory to arxiv-mcp-server
+WORKDIR /app/arxiv-mcp-server
+
+# Install arxiv-mcp-server dependencies
+RUN uv sync
+
+# Change directory back to root
+WORKDIR /app
 
 # Add uv tools to PATH
 ENV PATH="/root/.local/bin:$PATH"
@@ -34,7 +43,9 @@ RUN echo '{\
     "arxiv": {\
       "command": "uv",\
       "args": [\
-        "tool",\
+        "--directory",\
+        "./arxiv-mcp-server",\
+        "--isolated",\
         "run",\
         "arxiv-mcp-server",\
         "--storage-path", "/app/storage/papers"\

--- a/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_servers/arxiv/Dockerfile
+++ b/examples/aip-agent-quickstart/aip_agent_quickstart/mcp_servers/arxiv/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install uv
 WORKDIR /app
 
 # Clone multi-mcp repository
-RUN git clone https://github.com/samuellusandi/multi-mcp.git .
+RUN git clone https://github.com/RavindraGDP/multi-mcp-temp.git .
 
 # Install multi-mcp dependencies
 RUN uv sync
@@ -61,4 +61,4 @@ ENV ARXIV_STORAGE_PATH=/app/storage/papers
 EXPOSE 8006
 
 # Run the multi-mcp proxy directly
-CMD ["uv", "run", "main.py", "--transport", "sse", "--host", "0.0.0.0", "--port", "8006", "--config", "/app/config/mcp.json"]
+CMD ["uv", "run", "main.py", "--transport", "sse", "--host", "0.0.0.0", "--port", "8006", "--config", "/app/config/mcp.json", "--unify", "true"]

--- a/examples/aip-agent-quickstart/hello_world_arxiv_langgraph_mcp_sse.py
+++ b/examples/aip-agent-quickstart/hello_world_arxiv_langgraph_mcp_sse.py
@@ -23,6 +23,6 @@ if __name__ == "__main__":
 
     response = arxiv_agent.run(
         query="""Search for research papers about transformer large language models (LLMs) published between
-        January 2025 and May 2025. Focus on papers that discuss Transformer architectures and improvements."""
+        January 2024 and May 2024. Focus on papers that discuss Transformer architectures and improvements."""
     )
     print(f"Response: {response['output']}")


### PR DESCRIPTION
# Pull Request Description: Arxiv MCP Server Improvements

## Description

This PR addresses improvements and fixes to the Arxiv MCP server and its integration with the agent quickstart example. The changes include:

- Updates to the `arxiv_mcp_server` Dockerfile for better compatibility and reliability.
- Modifications to the MCP configuration in `configs.py`.
- Adjustments to the example script `hello_world_arxiv_langgraph_mcp_sse.py` to ensure correct usage with the updated MCP server.

These changes aim to streamline the development and testing workflow for the Arxiv MCP server and its usage with LangGraph-based agents.

---

## How to Test

### 1. Build and Run the Arxiv MCP Server Docker Container

```bash
# Ensure you are in the correct directory
cd examples/aip-agent-quickstart

# Stop and remove any existing containers (optional but recommended for a clean state)
docker compose stop arxiv_mcp_server

# Build and start the arxiv_mcp_server service
docker compose up --build arxiv_mcp_server
```

- Watch for any errors or warnings in the output.

### 2. Run the Example Script

In a new terminal, execute:

```bash
# (Optional) Activate your Python environment if needed
# source <your-env>/bin/activate

python hello_world_arxiv_langgraph_mcp_sse.py
```

- The script should connect to the Arxiv MCP server and print a response with relevant research papers.
- Ensure the output contains results and no exceptions are raised.

---
